### PR TITLE
ChatSpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Things you may want to cover:
 |name|string|null: false, add_index :users, :name, unique: true|
 ### Association
 - has_many :chats
-  has_many :groups_users
+- has_many :groups_users
 - has_many  :groups,  through:  :groups_users
 
 ## chatsテーブル
@@ -52,7 +52,7 @@ Things you may want to cover:
 |name|string|null: false|
 ### Association
 - has_many :chats
-  has_many :groups_users
+- has_many :groups_users
 - has_many  :users,  through:  :groups_users
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Things you may want to cover:
 |name|string|null: false, add_index :users, :name, unique: true|
 ### Association
 - has_many :chats
+  has_many :groups_users
 - has_many  :groups,  through:  :groups_users
 
 ## chatsテーブル

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-# DB設計
+# ChatSpace DB設計
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Things you may want to cover:
 ## chatsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -23,8 +23,38 @@ Things you may want to cover:
 
 * ...
 
-## groups_usersテーブル
+# chatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false, add_index :users, :username, unique: true|
+### Association
+- has_many :chats
+- has_many  :groups,  through:  :groups_users
 
+## chatsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|postingtime|string||
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+### Association
+- has_many :chats
+- has_many  :users,  through:  :groups_users
+
+## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false, add_index :users, :username, unique: true|
+|name|string|null: false, add_index :users, :name, unique: true|
 ### Association
 - has_many :chats
 - has_many  :groups,  through:  :groups_users

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-# ChatSpace DB設計
+# DB設計
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|
-|postingtime|string||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :chats
 - has_many  :users,  through:  :groups_users

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-# chatSpace DB設計
+# ChatSpace DB設計
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Things you may want to cover:
 |name|string|null: false|
 ### Association
 - has_many :chats
+  has_many :groups_users
 - has_many  :users,  through:  :groups_users
 
 ## groups_usersテーブル


### PR DESCRIPTION
# What
ChatSpace開発にあたりDB設計を実装する。
・各テーブルごとに、カラム構成，アソシエーションを設定
・usersテーブルとgroupsテーブルで中間テーブルを設定

## エンティティ,属性
①users テーブル：username, email, password
②chats テーブル：text, image, user_id, group_id
③groupsテーブル：groupname
④groups_usersテーブル：group_id, user_id

# Why
DB設計は必須であるため。
ユーザ情報を保存するため、usersテーブルを設定。
コメント投稿情報を保存するため、chatsテーブルを設定。
グループ情報を登録するため、groupsテーブルを設定。
usersテーブルとgroupsテーブルが多対多の関係になるため、中間テーブルを設定。
特記事項は以下の通り。
# Remarks
①usersテーブル：usernameの重複を避けるため、一意性制約を設定。