### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,22 @@
 $(function(){
   function buildHTML(chat){
+    console.log(chat)
 
-    var contents = `<div class="message">
+    var image = `<div class="lower-message">
+                   <img class="lower-message__image" src= ${chat.image}>
+                 </div>`
+
+    var name_date =`<div class="message", data-message-id="${chat.id}">
+                      <div class="upper-message">
+                        <div class="upper-message__user-name">
+                          ${chat.name}
+                        </div>
+                      <div class="upper-message__date">
+                        ${chat.date}
+                      </div>
+                    </div>`;
+
+    var contents = `<div class="message", data-message-id="${chat.id}">
                       <div class="upper-message">
                         <div class="upper-message__user-name">
                           ${chat.name}
@@ -17,17 +32,17 @@ $(function(){
                       </div>
                     </div>`;
 
-    if (chat.image.url == null) {
-      var html = `${contents}`;
-
-    } else {
+    if (chat.content && chat.image) {
       var html = `${contents}
-                  <div class="lower-message">
-                    <img class="lower-message__image" src= ${chat.image.url}>
-                  </div>`;
-    }
+                    ${image}`;
+    } else if (chat.image) {
+      var html = `${name_date}
+                    ${image}`;
+    } else {
+      var html = `${contents}`;
+    };
     return html;
-  }
+  };
 
   $('#new_chat').on('submit', function(e){
     e.preventDefault()
@@ -52,4 +67,31 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     })
   })
-})
+  var reloadChats = function () {
+    if (window.location.href.match(/\/groups\/\d+\/chats/)){
+      var last_message_id = $('.message:last').data("message-id");
+      console.log(last_message_id);
+
+      $.ajax({
+        url: "api/chats",
+        type: 'GET', 
+        dataType: 'json', 
+        data: {last_id: last_message_id}
+      })
+      .done(function (chats) {
+        console.log(chats)
+        var insertHTML = '';
+        chats.forEach(function (chat) {
+          insertHTML = buildHTML(chat);
+          console.log(chat);
+          $('.messages').append(insertHTML);
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+      })
+      .fail(function () {
+        alert('自動更新に失敗しました');
+      });
+    }
+  };
+  setInterval(reloadChats, 7000);
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,5 @@
 $(function(){
   function buildHTML(chat){
-    console.log(chat)
 
     var image = `<div class="lower-message">
                    <img class="lower-message__image" src= ${chat.image}>
@@ -70,7 +69,6 @@ $(function(){
   var reloadChats = function () {
     if (window.location.href.match(/\/groups\/\d+\/chats/)){
       var last_message_id = $('.message:last').data("message-id");
-      console.log(last_message_id);
 
       $.ajax({
         url: "api/chats",
@@ -79,11 +77,9 @@ $(function(){
         data: {last_id: last_message_id}
       })
       .done(function (chats) {
-        console.log(chats)
         var insertHTML = '';
         chats.forEach(function (chat) {
           insertHTML = buildHTML(chat);
-          console.log(chat);
           $('.messages').append(insertHTML);
         })
         $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -2,6 +2,6 @@ class Api::ChatsController < ApplicationController
   def index
     group = Group.find(params[:group_id])
     last_message_id = params[:id].to_i
-    @messages = group.chats.includes(:user).where("id > #{last_messages_id}")
+    @chats = group.chats.includes(:user).where("id > #{last_messages_id}")
   end
 end

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -1,7 +1,6 @@
 class Api::ChatsController < ApplicationController
   def index
-    group = Group.find(params[:group_id])
-    last_message_id = params[:id].to_i
-    @chats = group.chats.includes(:user).where("id > #{last_messages_id}")
+    @group = Group.find(params[:group_id])
+    @chats = @group.chats.includes(:user).where('id > ?', params[:last_id]) 
   end
 end

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -1,0 +1,7 @@
+class Api::ChatsController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.chats.includes(:user).where("id > #{last_messages_id}")
+  end
+end

--- a/app/views/api/chats/index.json.jbuilder
+++ b/app/views/api/chats/index.json.jbuilder
@@ -5,10 +5,3 @@ json.array! @chats do |chat|
   json.name chat.user.name
   json.id chat.id
 end
-
-
-# json.content @chat.content
-# json.name @chat.user.name
-# json.date @chat.created_at.strftime("%Y/%m/%d/ %H:%M")
-# json.image @chat.image
-# json.id @chat.id

--- a/app/views/api/chats/index.json.jbuilder
+++ b/app/views/api/chats/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @chats do |chat|
+  json.content chat.content
+  json.image chat.image.url
+  json.created_at chat.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name chat.user.user_name
+  json.id chat.id
+end

--- a/app/views/api/chats/index.json.jbuilder
+++ b/app/views/api/chats/index.json.jbuilder
@@ -1,7 +1,14 @@
 json.array! @chats do |chat|
   json.content chat.content
   json.image chat.image.url
-  json.created_at chat.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json.user_name chat.user.user_name
+  json.date chat.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.name chat.user.name
   json.id chat.id
 end
+
+
+# json.content @chat.content
+# json.name @chat.user.name
+# json.date @chat.created_at.strftime("%Y/%m/%d/ %H:%M")
+# json.image @chat.image
+# json.id @chat.id

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.user_name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,0 @@
-json.array! @messages do |message|
-  json.content message.content
-  json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json.user_name message.user.user_name
-  json.id message.id
-end

--- a/app/views/chats/_chat.html.haml
+++ b/app/views/chats/_chat.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{chat.id}"}
   .upper-message
     .upper-message__user-name
       = chat.user.name

--- a/app/views/chats/create.json.jbuilder
+++ b/app/views/chats/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content @chat.content
 json.name @chat.user.name
 json.date @chat.created_at.strftime("%Y/%m/%d/ %H:%M")
-json.image @chat.image
+json.image @chat.image.url
 json.id @chat.id

--- a/app/views/chats/create.json.jbuilder
+++ b/app/views/chats/create.json.jbuilder
@@ -2,4 +2,4 @@ json.content @chat.content
 json.name @chat.user.name
 json.date @chat.created_at.strftime("%Y/%m/%d/ %H:%M")
 json.image @chat.image
-json.user_id @chat.user.id
+json.id @chat.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :chats, only: [:index, :create]
+
+    namespace :api do
+      resources :chats, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ画面を自動的に更新することで、自分以外のユーザーが送信したメッセージも自動で追加表示されるようにチャット画面の自動更新機能を実装した。
「chats」テーブルでDB設計したため、カリキュラムで「messages」となっている箇所は「chats」
に置き換えて実装した。

## 実装内容
### １．[ _chat.html.haml]にカスタムデータ属性を追加。
                .message{"data-message-id": "#{chat.id}"} 
### ２．新規メッセージ確認用のアクションを(app/controllers/api/chats_controller.rb)に追加。
### ３．アクションを呼び出せるようルーティングを追加。
### ４．投稿内容をレスポンスできるように(app/views/api/chats/jbuilder)を作成。
### ５．取得した投稿データを表示できるようmessage.jsを編集。
　　　　・取得した最新のメッセージをブラウザのメッセージ一覧に追加し、数秒ごとにリクエスト
　　　　　させる。
　　　　・メッセージを取得したら画面をスクロールするようにし、自動更新が必要ない画面では
　　　　　行わないようにする。

# Why
別のユーザーの投稿メッセージはリロードしなければ表示できないため。


<a href="https://gyazo.com/f474660caf62308309d0eef93052a8d1"><img src="https://i.gyazo.com/f474660caf62308309d0eef93052a8d1.gif" alt="Image from Gyazo" width="1000"/></a>